### PR TITLE
Bump CLI version and update graph command

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -11,7 +11,7 @@ permissions:
 env:
   ENVIRONMENT: 'development'
   # Pinning the humctl version individually for each workflow to be able to test a version bump
-  HUMCTL_VERSION: '0.24.0'
+  HUMCTL_VERSION: '0.39.8'
 
 jobs:
   build:

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -14,7 +14,7 @@ env:
   ENVIRONMENT_ID: pr-${{ github.event.number }}
   ENVIRONMENT_NAME: PR-${{ github.event.number }}
   # Pinning the humctl version individually for each workflow to be able to test a version bump
-  HUMCTL_VERSION: '0.24.0'
+  HUMCTL_VERSION: '0.39.8'
 
 jobs:
   build:
@@ -174,14 +174,15 @@ jobs:
             echo "<details><summary>Resource Graph</summary>" >> pr_message.txt
             echo "" >> pr_message.txt
             echo "### Resource Graph:" >> pr_message.txt
-            echo "Use a [Graphviz](https://graphviz.org) viewer for a visual representation." >> pr_message.txt
+            echo "Click the link to open." >> pr_message.txt
             echo '```none' >> pr_message.txt
             echo "" >> pr_message.txt
             humctl resources graph \
-                --env ${{ env.ENVIRONMENT_ID }} \
+                env ${{ env.ENVIRONMENT_ID }} \
                 --token ${{ secrets.HUMANITEC_TOKEN }} \
                 --org ${{ vars.HUMANITEC_ORG }} \
-                --app ${{ vars.HUMANITEC_APP }} >> pr_message.txt
+                --app ${{ vars.HUMANITEC_APP }} \
+                --open=false >> pr_message.txt
             echo "" >> pr_message.txt
             echo '```' >> pr_message.txt
             echo "" >> pr_message.txt


### PR DESCRIPTION
This PR bumps the `humctl` version to a recent one and adjusts the CLI call for Resource Graph generation.

The present repo is the backing repo to the "[Ephemeral envs](https://developer.humanitec.com/platform-orchestrator/guides/developers/ci-cd/deploy-ephemeral-environments/)" tutorial.

Note: the failing workflow on this PR is fine, the repo is meant to be used as a template and not set up to perform actual deployments.